### PR TITLE
Use async-fn-in-trait nightly feature

### DIFF
--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -10,7 +10,6 @@ reqwest = { version = "0.11.12", features = [ "json"] }
 url = "2.3.1"
 serde = { version = "1.0.145", features = [ "derive" ] }
 serde_json = "1.0.85"
-async-trait = "0.1.58"
 policy-evaluator = {git = "https://github.com/kubewarden/policy-evaluator"}
 k8s-openapi = { version = "0.16.0", default-features = false, features = ["v1_24"] }
 thiserror = "1.0.37"

--- a/library/src/http.rs
+++ b/library/src/http.rs
@@ -1,5 +1,4 @@
 use crate::{Input, OpaClientError, OpenPolicyAgentClient, Output};
-use async_trait::async_trait;
 use reqwest::Client;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -27,7 +26,6 @@ pub struct OpenPolicyAgentHttpClient {
     url: Url,
 }
 
-#[async_trait(?Send)]
 impl OpenPolicyAgentClient for OpenPolicyAgentHttpClient {
     /// Construct a new client given an endpoint.
     fn new(bytes: &[u8]) -> Result<Self, OpaClientError> {

--- a/library/src/lib.rs
+++ b/library/src/lib.rs
@@ -1,4 +1,5 @@
-use async_trait::async_trait;
+#![feature(async_fn_in_trait)]
+#![allow(incomplete_features)]
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::Error as JsonError;
@@ -47,7 +48,6 @@ impl From<Utf8Error> for OpaClientError {
     }
 }
 
-#[async_trait(?Send)]
 pub trait OpenPolicyAgentClient {
     /// Instantiate a new instance of a struct implementing this trait.
     fn new(bytes: &[u8]) -> Result<Self, OpaClientError>

--- a/library/src/local_wasm.rs
+++ b/library/src/local_wasm.rs
@@ -1,5 +1,4 @@
 use crate::{OpaClientError, OpenPolicyAgentClient};
-use async_trait::async_trait;
 use policy_evaluator::burrego::Evaluator;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
@@ -18,7 +17,6 @@ impl OpenPolicyAgentWasmClient {
     }
 }
 
-#[async_trait(?Send)]
 impl OpenPolicyAgentClient for OpenPolicyAgentWasmClient {
     fn new(wasm: &[u8]) -> Result<Self, OpaClientError> {
         Ok(Self {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+# Before upgrading check that everything is available on all tier1 targets here:
+# https://rust-lang.github.io/rustup-components-history
+[toolchain]
+channel = "nightly-2022-11-19"


### PR DESCRIPTION
This commit removes the async-trait crate dependency in favour of the rustc nightly feature async-fn-in-trait (AFIT).

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>